### PR TITLE
feat(customer): merge phone fields, add postal_code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Local plans and notes
+.cursor/plans/
+
+# Helm SQL init files (generated, not source-controlled here)
+helm/files/*.sql
+
+# Helm local value overrides
+helm/*overrides.yaml

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_TAG  ?= latest
 
 RELEASE    := celadon
 CHART_DIR  := helm
-VALUES_MINIKUBE := helm/values-minikube.yaml
+VALUES_MINIKUBE := helm/values-minikube-overrides.yaml
 DB_STATEFULSET  := celadon-database
 DB_PVC          := data-celadon-database-0
 APP_SERVICE     := celadon

--- a/celadon/models/customer.py
+++ b/celadon/models/customer.py
@@ -2,36 +2,39 @@ from textwrap import dedent
 
 
 class Customer:
-    SELECT_ALL = 'SELECT * FROM customers'
-    SELECT_ONE = SELECT_ALL + ' WHERE customers.id = %s'
+    SELECT_ALL = dedent('''\
+        SELECT id, name, nickname, phone_number, address, postal_code,
+               personal_customs_clearance_code
+        FROM customers
+    ''')
+    SELECT_ONE = SELECT_ALL.rstrip() + ' WHERE id = %s\n'
     INSERT = dedent('''\
         INSERT INTO customers
-            (name, nickname, cellular_phone_number, home_phone_number,
-             address, personal_customs_clearance_code)
-        VALUES (%(name)s, %(nickname)s, %(cellular_phone_number)s,
-                %(home_phone_number)s, %(address)s,
-                %(personal_customs_clearance_code)s)
+            (name, nickname, phone_number, address, postal_code,
+             personal_customs_clearance_code)
+        VALUES (%(name)s, %(nickname)s, %(phone_number)s, %(address)s,
+                %(postal_code)s, %(personal_customs_clearance_code)s)
         RETURNING id
     ''')
     UPDATE = dedent('''\
         UPDATE customers SET
             name = %(name)s,
             nickname = %(nickname)s,
-            cellular_phone_number = %(cellular_phone_number)s,
-            home_phone_number = %(home_phone_number)s,
+            phone_number = %(phone_number)s,
             address = %(address)s,
+            postal_code = %(postal_code)s,
             personal_customs_clearance_code = %(personal_customs_clearance_code)s
         WHERE id = %(id)s
     ''')
 
-    def __init__(self, id, name, nickname, cellular_phone_number,
-                 home_phone_number, address, personal_customs_clearance_code):
+    def __init__(self, id, name, nickname, phone_number, address, postal_code,
+                 personal_customs_clearance_code):
         self.id = id
         self.name = name
         self.nickname = nickname
-        self.cellular_phone_number = cellular_phone_number
-        self.home_phone_number = home_phone_number
+        self.phone_number = phone_number
         self.address = address
+        self.postal_code = postal_code
         self.personal_customs_clearance_code = personal_customs_clearance_code
 
     def to_dict(self):
@@ -39,9 +42,9 @@ class Customer:
             'id': self.id,
             'name': self.name,
             'nickname': self.nickname,
-            'cellular_phone_number': self.cellular_phone_number,
-            'home_phone_number': self.home_phone_number,
+            'phone_number': self.phone_number,
             'address': self.address,
+            'postal_code': self.postal_code,
             'personal_customs_clearance_code': self.personal_customs_clearance_code,
         }
 
@@ -51,8 +54,8 @@ class Customer:
             d.get('id'),
             d.get('name', ''),
             d.get('nickname', ''),
-            d.get('cellular_phone_number', ''),
-            d.get('home_phone_number', ''),
+            d.get('phone_number', ''),
             d.get('address', ''),
+            d.get('postal_code', ''),
             d.get('personal_customs_clearance_code', ''),
         )

--- a/celadon/static/customers.js
+++ b/celadon/static/customers.js
@@ -5,9 +5,9 @@ const PAGE_SIZE = 20;
 const COLUMNS = [
     { field: 'name', label: 'Name', summary: true },
     { field: 'nickname', label: 'Nickname', summary: true },
-    { field: 'cellular_phone_number', label: 'Cellular Phone', tablet: false },
-    { field: 'home_phone_number', label: 'Home Phone', tablet: false },
+    { field: 'phone_number', label: 'Phone', tablet: false, inputType: 'tel' },
     { field: 'address', label: 'Address' },
+    { field: 'postal_code', label: 'Postal Code', tablet: false },
     { field: 'personal_customs_clearance_code', label: 'Customs Code' },
 ];
 
@@ -361,11 +361,11 @@ function sortCustomers(list) {
 // --- Modal helpers ---
 
 function buildFormFields(customer) {
-    return COLUMNS.map(({ field, label }) => `
+    return COLUMNS.map(({ field, label, inputType }) => `
         <div class="mb-3">
             <label for="field-${field}" class="form-label">${label}</label>
             <input
-                type="text"
+                type="${inputType ?? 'text'}"
                 class="form-control"
                 id="field-${field}"
                 name="${field}"

--- a/db/02_create_tables.sql
+++ b/db/02_create_tables.sql
@@ -30,9 +30,9 @@ CREATE TABLE IF NOT EXISTS customers (
     id                              SERIAL PRIMARY KEY,
     name                            TEXT,
     nickname                        TEXT,
-    cellular_phone_number           TEXT,
-    home_phone_number               TEXT,
+    phone_number                    TEXT,
     address                         TEXT,
+    postal_code                     TEXT,
     personal_customs_clearance_code TEXT
 );
 

--- a/db/03_migrate_customers.sql
+++ b/db/03_migrate_customers.sql
@@ -1,0 +1,10 @@
+ALTER TABLE customers
+    ADD COLUMN phone_number TEXT,
+    ADD COLUMN postal_code TEXT;
+
+UPDATE customers
+    SET phone_number = COALESCE(NULLIF(cellular_phone_number, ''), home_phone_number);
+
+ALTER TABLE customers
+    DROP COLUMN cellular_phone_number,
+    DROP COLUMN home_phone_number;

--- a/helm/templates/database/configmap.yaml
+++ b/helm/templates/database/configmap.yaml
@@ -7,8 +7,6 @@ metadata:
   labels: {{- include "celadon.database.labels" . | nindent 4 }}
   annotations: {{- include "celadon.annotations" . | nindent 4 }}
 data:
-  01_init_db.sql: |
-    {{- required "helm/files/01_init_db.sql is missing" (.Files.Get "files/01_init_db.sql") | nindent 4 }}
   02_create_tables.sql: |
     {{- required "helm/files/02_create_tables.sql is missing" (.Files.Get "files/02_create_tables.sql") | nindent 4 }}
 {{- end }}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -121,7 +121,7 @@ class TestItem:
 
 class TestCustomer:
     def _make_row(self):
-        return (1, 'Alice', 'ali', '010-1234-5678', '', '123 Main St', 'P123')
+        return (1, 'Alice', 'ali', '010-1234-5678', '123 Main St', '12345', 'P123')
 
     def test_get_customers(self, db_instance, mock_conn):
         cur = _make_cursor(rows=[self._make_row()])
@@ -138,7 +138,7 @@ class TestCustomer:
         assert result[0].name == 'Alice'
 
     def test_add_customer(self, db_instance, mock_conn):
-        customer = Customer(None, 'Bob', 'bobby', '010-9999-8888', '', '456 Elm St', 'P456')
+        customer = Customer(None, 'Bob', 'bobby', '010-9999-8888', '456 Elm St', '67890', 'P456')
         cur = _make_cursor(fetchone_value=3)
         mock_conn.cursor.return_value = cur
         result = db_instance.add_customer(customer)
@@ -146,7 +146,7 @@ class TestCustomer:
         assert result == 3
 
     def test_update_customer(self, db_instance, mock_conn):
-        customer = Customer(1, 'Bob', 'bobby', '010-9999-8888', '', '456 Elm St', 'P456')
+        customer = Customer(1, 'Bob', 'bobby', '010-9999-8888', '456 Elm St', '67890', 'P456')
         cur = _make_cursor()
         mock_conn.cursor.return_value = cur
         db_instance.update_customer(customer)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,18 +13,18 @@ class TestCustomer:
             'id': 1,
             'name': 'Alice',
             'nickname': 'ali',
-            'cellular_phone_number': '010-1234-5678',
-            'home_phone_number': '02-123-4567',
+            'phone_number': '010-1234-5678',
             'address': '123 Main St',
+            'postal_code': '12345',
             'personal_customs_clearance_code': 'P123456789',
         }
         c = Customer.from_dict(d)
         assert c.id == 1
         assert c.name == 'Alice'
         assert c.nickname == 'ali'
-        assert c.cellular_phone_number == '010-1234-5678'
-        assert c.home_phone_number == '02-123-4567'
+        assert c.phone_number == '010-1234-5678'
         assert c.address == '123 Main St'
+        assert c.postal_code == '12345'
         assert c.personal_customs_clearance_code == 'P123456789'
 
     def test_from_dict_defaults(self):
@@ -32,9 +32,9 @@ class TestCustomer:
         assert c.id is None
         assert c.name == ''
         assert c.nickname == ''
-        assert c.cellular_phone_number == ''
-        assert c.home_phone_number == ''
+        assert c.phone_number == ''
         assert c.address == ''
+        assert c.postal_code == ''
         assert c.personal_customs_clearance_code == ''
 
     def test_to_dict_roundtrip(self):
@@ -42,9 +42,9 @@ class TestCustomer:
             'id': 2,
             'name': 'Bob',
             'nickname': 'bobby',
-            'cellular_phone_number': '010-9999-8888',
-            'home_phone_number': '',
+            'phone_number': '010-9999-8888',
             'address': '456 Elm St',
+            'postal_code': '67890',
             'personal_customs_clearance_code': 'P987654321',
         }
         assert Customer.from_dict(d).to_dict() == d

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -274,7 +274,7 @@ class TestPurchaseRoutes:
 class TestCustomerRoutes:
     def test_get_list(self, flask_client):
         _, mock_app = flask_client
-        expected = [{"id": 1, "name": "c", "nickname": "", "cellular_phone_number": ""}]
+        expected = [{"id": 1, "name": "c", "nickname": "", "phone_number": ""}]
         mock_app.get_customers.return_value = expected
         with patch("celadon.server.server.app", mock_app):
             with _authed_client() as client:
@@ -285,7 +285,7 @@ class TestCustomerRoutes:
 
     def test_post_valid_json(self, flask_client):
         _, mock_app = flask_client
-        created = {"id": 2, "name": "test", "nickname": "", "cellular_phone_number": ""}
+        created = {"id": 2, "name": "test", "nickname": "", "phone_number": ""}
         mock_app.add_customer.return_value = created
         with patch("celadon.server.server.app", mock_app):
             with _authed_client() as client:


### PR DESCRIPTION
## Summary

- Merged `cellular_phone_number` and `home_phone_number` into a single `phone_number` field (cellular takes priority via `COALESCE`)
- Added `postal_code` field to customers
- Updated phone input to `type="tel"` in the customer form UI

## Migration

Run `db/03_migrate_customers.sql` against existing databases before deploying.

Made with [Cursor](https://cursor.com)