### PR TITLE
feat(sales): add end-to-end delete sale functionality

### DIFF
--- a/celadon/application.py
+++ b/celadon/application.py
@@ -92,6 +92,10 @@ class Application:
         self._database.update_sale(sale)
         return self.get_sale(sale.id)
 
+    def delete_sale(self, id):
+        self.get_sale(id)  # raises NotFound if missing
+        self._database.delete_sale(id)
+
     # Auth methods are kept here for now. Extract to a dedicated AuthApplication
     # class if auth logic grows (e.g. roles, permissions, audit logging).
     def get_user_by_email(self, email):

--- a/celadon/db.py
+++ b/celadon/db.py
@@ -100,6 +100,10 @@ class Database:
         with self._conn.cursor() as cur:
             cur.execute(Sale.UPDATE, sale.to_dict())
 
+    def delete_sale(self, id):
+        with self._conn.cursor() as cur:
+            cur.execute(Sale.DELETE, [id])
+
     def get_user_by_email(self, email):
         with self._conn.cursor() as cur:
             cur.execute(User.SELECT_ONE_BY_EMAIL, [email])

--- a/celadon/models/sale.py
+++ b/celadon/models/sale.py
@@ -44,6 +44,7 @@ class Sale:
             shipped_date = %(shipped_date)s
         WHERE id = %(id)s
     ''')
+    DELETE = 'DELETE FROM sales WHERE id = %s'
 
     def __init__(self, id, customer_id, description, sale_price_won,
                  shipping_cost_dollar, sales_date, paid_date, shipped_date,

--- a/celadon/server.py
+++ b/celadon/server.py
@@ -116,7 +116,7 @@ def customer(customer_id=None):
 
 
 @server.route('/sale', methods=['GET', 'POST'])
-@server.route('/sale/<int:sale_id>', methods=['GET', 'PUT'])
+@server.route('/sale/<int:sale_id>', methods=['GET', 'PUT', 'DELETE'])
 @require_login
 def sale(sale_id=None):
     if sale_id is None:
@@ -129,6 +129,9 @@ def sale(sale_id=None):
             s = Sale.from_dict(get_request_json())
             s.id = sale_id
             return jsonify(server.app.update_sale(s))
+        elif request.method == 'DELETE':
+            server.app.delete_sale(sale_id)
+            return '', 204
         else:
             return jsonify(server.app.get_sale(sale_id))
 

--- a/celadon/static/api.js
+++ b/celadon/static/api.js
@@ -22,3 +22,4 @@ export const updateCustomer = (id, data) => request('PUT', `/customer/${id}`, da
 export const getSales = () => request('GET', '/sale');
 export const createSale = (data) => request('POST', '/sale', data);
 export const updateSale = (id, data) => request('PUT', `/sale/${id}`, data);
+export const deleteSale = (id) => request('DELETE', `/sale/${id}`);

--- a/celadon/static/sales.js
+++ b/celadon/static/sales.js
@@ -1,4 +1,4 @@
-import { getSales, createSale, updateSale, getCustomers } from './api.js';
+import { getSales, createSale, updateSale, deleteSale, getCustomers } from './api.js';
 
 const PAGE_SIZE = 20;
 
@@ -200,6 +200,13 @@ function bindEvents() {
         const shippedBtn = e.target.closest('.btn-mark-shipped');
         if (shippedBtn) {
             openShippedModal(Number(shippedBtn.dataset.id));
+            return;
+        }
+
+        // Delete button
+        const deleteBtn = e.target.closest('.btn-delete-sale');
+        if (deleteBtn) {
+            handleDelete(Number(deleteBtn.dataset.id));
         }
     });
 }
@@ -354,12 +361,19 @@ function renderBody() {
                     </svg>
                     <span class="btn-label ms-1">Mark Paid</span>
                 </button>
-                <button class="btn btn-outline-success btn-sm btn-mark-shipped" data-id="${sale.id}" aria-label="Mark as shipped" ${sale.status !== 'PAID' ? 'disabled' : ''}>
+                <button class="btn btn-outline-success btn-sm btn-mark-shipped me-1" data-id="${sale.id}" aria-label="Mark as shipped" ${sale.status !== 'PAID' ? 'disabled' : ''}>
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
                         <path d="M8.5 6a.5.5 0 0 0-1 0v1.5H6a.5.5 0 0 0 0 1h1.5V10a.5.5 0 0 0 1 0V8.5H10a.5.5 0 0 0 0-1H8.5z"/>
                         <path d="M0 3.5A1.5 1.5 0 0 1 1.5 2h9A1.5 1.5 0 0 1 12 3.5V5h1.02a1.5 1.5 0 0 1 1.17.563l1.481 1.85a1.5 1.5 0 0 1 .329.938V10.5a1.5 1.5 0 0 1-1.5 1.5H14a2 2 0 1 1-4 0H5a2 2 0 1 1-3.998-.085A1.5 1.5 0 0 1 0 10.5zm1.294 7.456A2 2 0 0 1 3 10a2 2 0 0 1 1.732 1H11V3.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5v7a.5.5 0 0 0 .294.456M12 10a2 2 0 0 1 1.732 1h.768a.5.5 0 0 0 .5-.5V8.35a.5.5 0 0 0-.11-.312l-1.48-1.85A.5.5 0 0 0 13.02 6H12zm-9 1a1 1 0 1 0 0 2 1 1 0 0 0 0-2m9 0a1 1 0 1 0 0 2 1 1 0 0 0 0-2"/>
                     </svg>
                     <span class="btn-label ms-1">Ship</span>
+                </button>
+                <button class="btn btn-outline-danger btn-sm btn-delete-sale" data-id="${sale.id}" aria-label="Delete">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">
+                        <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                        <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                    </svg>
+                    <span class="btn-label ms-1">Delete</span>
                 </button>
             </td>`;
 
@@ -386,12 +400,19 @@ function renderBody() {
                         </svg>
                         Mark Paid
                     </button>
-                    <button class="btn btn-outline-success btn-sm btn-mark-shipped" data-id="${sale.id}" aria-label="Mark as shipped" ${sale.status !== 'PAID' ? 'disabled' : ''}>
+                    <button class="btn btn-outline-success btn-sm btn-mark-shipped me-1" data-id="${sale.id}" aria-label="Mark as shipped" ${sale.status !== 'PAID' ? 'disabled' : ''}>
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
                             <path d="M8.5 6a.5.5 0 0 0-1 0v1.5H6a.5.5 0 0 0 0 1h1.5V10a.5.5 0 0 0 1 0V8.5H10a.5.5 0 0 0 0-1H8.5z"/>
                             <path d="M0 3.5A1.5 1.5 0 0 1 1.5 2h9A1.5 1.5 0 0 1 12 3.5V5h1.02a1.5 1.5 0 0 1 1.17.563l1.481 1.85a1.5 1.5 0 0 1 .329.938V10.5a1.5 1.5 0 0 1-1.5 1.5H14a2 2 0 1 1-4 0H5a2 2 0 1 1-3.998-.085A1.5 1.5 0 0 1 0 10.5zm1.294 7.456A2 2 0 0 1 3 10a2 2 0 0 1 1.732 1H11V3.5a.5.5 0 0 0-.5-.5h-9a.5.5 0 0 0-.5.5v7a.5.5 0 0 0 .294.456M12 10a2 2 0 0 1 1.732 1h.768a.5.5 0 0 0 .5-.5V8.35a.5.5 0 0 0-.11-.312l-1.48-1.85A.5.5 0 0 0 13.02 6H12zm-9 1a1 1 0 1 0 0 2 1 1 0 0 0 0-2m9 0a1 1 0 1 0 0 2 1 1 0 0 0 0-2"/>
                         </svg>
                         Ship
+                    </button>
+                    <button class="btn btn-outline-danger btn-sm btn-delete-sale" data-id="${sale.id}" aria-label="Delete">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z"/>
+                            <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z"/>
+                        </svg>
+                        Delete
                     </button>
                 </td>
             </tr>`;
@@ -615,6 +636,20 @@ function openShippedModal(id) {
         document.getElementById('sale-shipping')?.focus();
     }, { once: true });
     modal.show();
+}
+
+async function handleDelete(id) {
+    const sale = state.sales.find((s) => s.id === id);
+    if (!sale) return;
+    const label = sale.customer_name ? `sale for ${sale.customer_name}` : 'this sale';
+    if (!confirm(`Delete ${label}? This cannot be undone.`)) return;
+    try {
+        await deleteSale(id);
+        showToast('Sale deleted.', 'success');
+        await loadSales();
+    } catch (err) {
+        showToast(err.message, 'danger');
+    }
 }
 
 function saleToFormData(sale) {

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -207,3 +207,17 @@ class TestSale:
         assert app_instance.update_sale(sale) == {'id': 6, 'status': 'pending'}
         mock_db.update_sale.assert_called_once_with(sale)
         mock_db.get_sale.assert_called_once_with(6)
+
+    def test_delete_sale_found(self, mock_db, app_instance):
+        row = MagicMock()
+        row.to_dict.return_value = {'id': 7, 'status': 'SOLD'}
+        mock_db.get_sale.return_value = [row]
+        app_instance.delete_sale(7)
+        mock_db.get_sale.assert_called_once_with(7)
+        mock_db.delete_sale.assert_called_once_with(7)
+
+    def test_delete_sale_not_found(self, mock_db, app_instance):
+        mock_db.get_sale.return_value = []
+        with pytest.raises(NotFound, match='Sale 99 not found'):
+            app_instance.delete_sale(99)
+        mock_db.delete_sale.assert_not_called()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -189,6 +189,12 @@ class TestSale:
         db_instance.update_sale(sale)
         cur.execute.assert_called_once_with(Sale.UPDATE, sale.to_dict())
 
+    def test_delete_sale(self, db_instance, mock_conn):
+        cur = _make_cursor()
+        mock_conn.cursor.return_value = cur
+        db_instance.delete_sale(1)
+        cur.execute.assert_called_once_with(Sale.DELETE, [1])
+
 
 class TestSession:
     def test_get_session_returns_data_when_found(self, db_instance, mock_conn):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -426,6 +426,25 @@ class TestSaleRoutes:
         assert isinstance(arg, Sale)
         assert arg.id == 1
 
+    def test_delete_one(self, flask_client):
+        _, mock_app = flask_client
+        mock_app.delete_sale.return_value = None
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.delete("/sale/1")
+        assert r.status_code == 204
+        assert r.data == b''
+        mock_app.delete_sale.assert_called_once_with(1)
+
+    def test_delete_one_not_found(self, flask_client):
+        _, mock_app = flask_client
+        mock_app.delete_sale.side_effect = NotFound(description="Sale 99 not found")
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.delete("/sale/99")
+        assert r.status_code == 404
+        assert r.get_json() == {"error": "Sale 99 not found"}
+
 
 class TestItemRoutes:
     def test_get_list(self, flask_client):


### PR DESCRIPTION
## Summary

- Add `DELETE /sale/<id>` route returning 204
- Add delete logic through all layers: SQL constant, DB, application, Flask route
- Add Delete button with confirmation dialog and toast to the sales UI
- Add tests across db, application, and server layers (100% coverage maintained)

Made with [Cursor](https://cursor.com)