### PR TITLE
feat(dev): add make run target and auth warning log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ NAMESPACE  ?= celadon
 
 BUILD_TAG  ?= latest
 
+DATABASE_URL          ?=
+GOOGLE_CLIENT_ID      ?=
+GOOGLE_CLIENT_SECRET  ?=
+FLASK_SESSION_SIGNING_KEY ?=
+
 RELEASE    := celadon
 CHART_DIR  := helm
 VALUES_MINIKUBE := helm/values-minikube-overrides.yaml
@@ -18,7 +23,7 @@ GET_ENDPOINTS := / /purchaser /purchase /customer /sale /item
 .PHONY: help test test-lint test-unit build \
         minikube-deploy minikube-deploy-full \
         minikube-remove minikube-remove-full \
-        minikube-get
+        minikube-get run
 
 help:
 	@echo "Usage: make <target> [VAR=value ...]"
@@ -29,6 +34,8 @@ help:
 	@echo "  test-unit               Run unit tests only (pytest)"
 	@echo "  build [BUILD_TAG=latest]"
 	@echo "                          Build the celadon Docker image"
+	@echo "  run [DATABASE_URL=...] [GOOGLE_CLIENT_ID=...] [GOOGLE_CLIENT_SECRET=...] [FLASK_SESSION_SIGNING_KEY=...]"
+	@echo "                          Run the app locally with Flask dev server"
 	@echo "  minikube-deploy [TAG=<datetime>] [KUBE_CONTEXT=minikube] [NAMESPACE=celadon]"
 	@echo "                          Build image and deploy to Minikube via Helm"
 	@echo "  minikube-deploy-full [TAG=<datetime>] [KUBE_CONTEXT=minikube] [NAMESPACE=celadon]"
@@ -39,6 +46,20 @@ help:
 	@echo "                          Helm uninstall, delete DB PVC, remove all celadon images from Minikube and Docker"
 	@echo "  minikube-get [KUBE_CONTEXT=minikube] [NAMESPACE=celadon]"
 	@echo "                          Port-forward and smoke-test all GET endpoints"
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+run:
+	@test -n "$(DATABASE_URL)"         || (echo "ERROR: DATABASE_URL is required"; exit 1)
+	@test -n "$(GOOGLE_CLIENT_ID)"     || (echo "ERROR: GOOGLE_CLIENT_ID is required"; exit 1)
+	@test -n "$(GOOGLE_CLIENT_SECRET)" || (echo "ERROR: GOOGLE_CLIENT_SECRET is required"; exit 1)
+	@test -n "$(FLASK_SESSION_SIGNING_KEY)" || (echo "ERROR: FLASK_SESSION_SIGNING_KEY is required"; exit 1)
+	DATABASE_URL="$(DATABASE_URL)" \
+	GOOGLE_CLIENT_ID="$(GOOGLE_CLIENT_ID)" \
+	GOOGLE_CLIENT_SECRET="$(GOOGLE_CLIENT_SECRET)" \
+	FLASK_SESSION_SIGNING_KEY="$(FLASK_SESSION_SIGNING_KEY)" \
+	poetry run flask --app celadon.server run --port $(APP_PORT)
 
 # ---------------------------------------------------------------------------
 # test

--- a/celadon/auth.py
+++ b/celadon/auth.py
@@ -1,8 +1,11 @@
 import hashlib
+import logging
 import os
 import functools
 from flask import Blueprint, session, redirect, url_for, abort, current_app, send_from_directory
 from authlib.integrations.flask_client import OAuth
+
+logger = logging.getLogger(__name__)
 
 auth_bp = Blueprint('auth', __name__)
 oauth = OAuth()
@@ -52,6 +55,7 @@ def google_callback():
 
     user = current_app.app.get_user_by_email(email)
     if user is None:
+        logger.warning('Login attempt by unrecognized email: %s', email)
         abort(403)
 
     session.sid = hashlib.sha256(email.encode()).hexdigest()


### PR DESCRIPTION
## Summary
- Adds \`make run\` target for running the app locally with a port-forwarded DB
- Accepts \`DATABASE_URL\`, \`GOOGLE_CLIENT_ID\`, \`GOOGLE_CLIENT_SECRET\`, and \`FLASK_SESSION_SIGNING_KEY\` as inputs, falling back to env vars
- Adds a warning log when a Google login attempt uses an email not in the \`users\` table

Made with [Cursor](https://cursor.com)