### PR TITLE
fix(models): Coerce null optional text via OptionalText

### DIFF
--- a/celadon/models/customer.py
+++ b/celadon/models/customer.py
@@ -1,6 +1,9 @@
 from textwrap import dedent
 from typing import ClassVar
+
 from pydantic import BaseModel, ConfigDict
+
+from celadon.models.validator import OptionalText
 
 
 class Customer(BaseModel):
@@ -31,9 +34,9 @@ class Customer(BaseModel):
     ''')
 
     id: int | None = None
-    name: str = ''
-    nickname: str = ''
-    phone_number: str = ''
-    address: str = ''
-    postal_code: str = ''
-    personal_customs_clearance_code: str = ''
+    name: OptionalText = ''
+    nickname: OptionalText = ''
+    phone_number: OptionalText = ''
+    address: OptionalText = ''
+    postal_code: OptionalText = ''
+    personal_customs_clearance_code: OptionalText = ''

--- a/celadon/models/item.py
+++ b/celadon/models/item.py
@@ -1,6 +1,9 @@
 from textwrap import dedent
 from typing import ClassVar
+
 from pydantic import BaseModel, ConfigDict
+
+from celadon.models.validator import OptionalText
 
 
 class Item(BaseModel):
@@ -18,7 +21,7 @@ class Item(BaseModel):
     ''')
 
     id: int | None = None
-    brand: str = ''
-    name: str = ''
+    brand: OptionalText = ''
+    name: OptionalText = ''
     quantity: int = 0
     cost: float = 0.0

--- a/celadon/models/purchase.py
+++ b/celadon/models/purchase.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
 
 from celadon.models.item import Item
+from celadon.models.validator import OptionalText
 
 
 class Purchase(BaseModel):
@@ -29,7 +30,7 @@ class Purchase(BaseModel):
     purchase_date: date
     cost: float = 0.0
     purchaser_id: int
-    purchaser_name: str = ''
+    purchaser_name: OptionalText = ''
     items: list[Item] = []
 
     SERVER_FIELDS: ClassVar[frozenset[str]] = frozenset({'purchaser_name'})

--- a/celadon/models/purchaser.py
+++ b/celadon/models/purchaser.py
@@ -1,5 +1,8 @@
 from typing import ClassVar
+
 from pydantic import BaseModel, ConfigDict
+
+from celadon.models.validator import OptionalText
 
 
 class Purchaser(BaseModel):
@@ -10,5 +13,5 @@ class Purchaser(BaseModel):
     UPDATE: ClassVar[str] = 'UPDATE purchasers SET name = %(name)s, is_active = %(is_active)s WHERE id = %(id)s'
 
     id: int | None = None
-    name: str = ''
+    name: OptionalText = ''
     is_active: bool = True

--- a/celadon/models/sale.py
+++ b/celadon/models/sale.py
@@ -5,6 +5,8 @@ from typing import ClassVar
 
 from pydantic import BaseModel, ConfigDict, computed_field, field_serializer, field_validator
 
+from celadon.models.validator import OptionalText
+
 
 class SaleStatus(Enum):
     SOLD = 'SOLD'
@@ -44,14 +46,14 @@ class Sale(BaseModel):
 
     id: int | None = None
     customer_id: int
-    description: str = ''
+    description: OptionalText = ''
     sale_price_won: int | None = None
     shipping_cost_dollar: float | None = None
     sales_date: date | None = None
     paid_date: date | None = None
     shipped_date: date | None = None
-    customer_name: str = ''
-    customer_nickname: str = ''
+    customer_name: OptionalText = ''
+    customer_nickname: OptionalText = ''
 
     SERVER_FIELDS: ClassVar[frozenset[str]] = frozenset({
         'customer_name', 'customer_nickname', 'status',

--- a/celadon/models/user.py
+++ b/celadon/models/user.py
@@ -1,5 +1,8 @@
 from typing import ClassVar
+
 from pydantic import BaseModel, ConfigDict
+
+from celadon.models.validator import OptionalText
 
 
 class User(BaseModel):
@@ -10,5 +13,5 @@ class User(BaseModel):
 
     id: int
     email: str
-    name: str
+    name: OptionalText = ''
     organization_id: int

--- a/celadon/models/validator.py
+++ b/celadon/models/validator.py
@@ -1,0 +1,10 @@
+from typing import Annotated
+
+from pydantic import BeforeValidator
+
+
+def _coerce_null_text(v: object) -> object:
+    return '' if v is None else v
+
+
+OptionalText = Annotated[str, BeforeValidator(_coerce_null_text)]

--- a/celadon/models/validator.py
+++ b/celadon/models/validator.py
@@ -3,8 +3,13 @@ from typing import Annotated
 from pydantic import BeforeValidator
 
 
-def _coerce_null_text(v: object) -> object:
-    return '' if v is None else v
+def _coerce_null_text(v: object) -> str:
+    """SQL/JSON null and strings only; reject numbers, dicts, lists, etc."""
+    if v is None:
+        return ''
+    if isinstance(v, str):
+        return v
+    raise ValueError('Value must be a string or null')
 
 
 OptionalText = Annotated[str, BeforeValidator(_coerce_null_text)]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -67,6 +67,14 @@ class TestCustomer:
         assert c.nickname == ''
         assert c.postal_code == ''
 
+    @pytest.mark.parametrize(
+        'bad_name',
+        [1, 1.5, True, [], {}, ['x']],
+    )
+    def test_optional_text_rejects_non_string(self, bad_name):
+        with pytest.raises(ValidationError):
+            Customer.model_validate({'name': bad_name})
+
 
 class TestItem:
     def test_model_validate_full(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,6 +51,22 @@ class TestCustomer:
         }
         assert Customer.model_validate(d).model_dump(mode='json') == d
 
+    def test_model_validate_null_strings_from_db(self):
+        """Postgres NULL maps to None; coerce to '' like empty TEXT columns."""
+        c = Customer.model_validate(
+            {
+                'id': 1,
+                'name': 'Alice',
+                'nickname': None,
+                'phone_number': None,
+                'address': None,
+                'postal_code': None,
+                'personal_customs_clearance_code': None,
+            }
+        )
+        assert c.nickname == ''
+        assert c.postal_code == ''
+
 
 class TestItem:
     def test_model_validate_full(self):
@@ -79,6 +95,13 @@ class TestItem:
         d = {'id': 5, 'brand': 'Adidas', 'name': 'Hat', 'quantity': 3, 'cost': 25.0}
         assert Item.model_validate(d).model_dump(mode='json') == d
 
+    def test_model_validate_null_strings_from_db(self):
+        item = Item.model_validate(
+            {'id': 1, 'brand': None, 'name': None, 'quantity': 1, 'cost': 1.0}
+        )
+        assert item.brand == ''
+        assert item.name == ''
+
 
 class TestPurchaser:
     def test_model_validate_full(self):
@@ -100,6 +123,10 @@ class TestPurchaser:
     def test_model_dump_roundtrip(self):
         d = {'id': 3, 'name': 'Depot', 'is_active': False}
         assert Purchaser.model_validate(d).model_dump(mode='json') == d
+
+    def test_model_validate_null_name_from_db(self):
+        p = Purchaser.model_validate({'id': 1, 'name': None})
+        assert p.name == ''
 
 
 class TestPurchase:
@@ -151,6 +178,14 @@ class TestPurchase:
         dt = datetime(2024, 5, 10, 14, 30, 0, tzinfo=timezone.utc)
         p = Purchase.model_validate({'purchase_date': dt, 'purchaser_id': 1})
         assert p.purchase_date == date(2024, 5, 10)
+
+    def test_model_validate_null_purchaser_name_from_db(self):
+        p = Purchase.model_validate({
+            'purchase_date': '2024-01-01',
+            'purchaser_id': 1,
+            'purchaser_name': None,
+        })
+        assert p.purchaser_name == ''
 
 
 class TestSale:
@@ -257,6 +292,28 @@ class TestSale:
         assert d['paid_date'] is None
         assert d['shipped_date'] is None
         assert d['status'] == 'SOLD'
+
+    def test_model_validate_null_strings_from_db(self):
+        sale = Sale.model_validate({
+            'customer_id': 1,
+            'description': None,
+            'customer_name': None,
+            'customer_nickname': None,
+        })
+        assert sale.description == ''
+        assert sale.customer_name == ''
+        assert sale.customer_nickname == ''
+
+
+class TestUser:
+    def test_model_validate_null_name_from_db(self):
+        u = User.model_validate({
+            'id': 1,
+            'email': 'a@b.com',
+            'name': None,
+            'organization_id': 2,
+        })
+        assert u.name == ''
 
 
 class TestServerFields:


### PR DESCRIPTION
## Summary

- Add `OptionalText` in `celadon/models/validator.py`: SQL/JSON `null` becomes `''`; only `str` or `null` are accepted (int, bool, dict, list, etc. raise validation errors).
- Apply `OptionalText` to nullable / join-backed string fields on Customer, Purchaser, Item, Purchase (`purchaser_name`), Sale (`description`, `customer_name`, `customer_nickname`), and User (`name`).
- Extend model tests for null coercion and strict non-string rejection.

## Why

Postgres `NULL` for `TEXT` columns was surfaced as Python `None`, which broke `str`-typed Pydantic fields (e.g. 422 on `GET /customer`). We normalize to empty string for API stability and reject non-strings at validation time.

## Security checklist

- [x] No hardcoded secrets or credentials
- [x] Input validation on affected fields (str or null only)
- [x] Auth unchanged
- [x] Error messages are generic validation failures
- [ ] N/A — GitHub Actions not changed in this PR

Add a `KD-` ticket to the PR title if your process requires it.

Made with [Cursor](https://cursor.com)