### PR TITLE
feat(helm): Run yoyo migrations as initContainer on app deployment

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: celadon
 description: A Helm chart for Celadon
 type: application
-version: 0.2.0
+version: 0.6.2
 appVersion: 0.2.0
 home: https://github.com/hanpeter/celadon
 sources:

--- a/helm/templates/application/deployment.yaml
+++ b/helm/templates/application/deployment.yaml
@@ -24,6 +24,21 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "celadon.imagePullSecrets" (dict "pullSecrets" .Values.application.image.pullSecrets "ctx" .) | nindent 8 }}
+      {{- if .Values.migrator.enabled }}
+      initContainers:
+        - name: celadon-migrate
+          image: {{ include "celadon.image" (dict "image" .Values.migrator.image "ctx" .) }}
+          imagePullPolicy: {{ .Values.migrator.image.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "celadon.database.name" . }}
+                  key: database_url
+            - name: USER
+              value: celadon-migrate
+          resources: {{- toYaml .Values.migrator.resources | nindent 12 }}
+      {{- end }}
       containers:
         - name: {{ include "celadon.application.name" . }}
           image: {{ include "celadon.image" (dict "image" .Values.application.image "ctx" .) }}

--- a/helm/templates/database/configmap.yaml
+++ b/helm/templates/database/configmap.yaml
@@ -7,6 +7,8 @@ metadata:
   labels: {{- include "celadon.database.labels" . | nindent 4 }}
   annotations: {{- include "celadon.annotations" . | nindent 4 }}
 data:
-  02_create_tables.sql: |
-    {{- required "helm/files/02_create_tables.sql is missing" (.Files.Get "files/02_create_tables.sql") | nindent 4 }}
+  {{- range $key, $val := .Values.database.initScripts }}
+  {{ $key }}: |
+    {{- tpl $val $ | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -10,7 +10,11 @@ data:
   {{- $host := .Values.connection.host | default (include "celadon.database.name" .) }}
   {{- $username := required "connection.username is required" .Values.connection.username }}
   {{- $password := required "connection.password is required" .Values.connection.password }}
-  database_url: "{{ printf "postgres://%s:%s@%s:%s/%s" $username $password $host .Values.connection.port .Values.connection.dbName | b64enc }}"
+  {{- $url := printf "postgres://%s:%s@%s:%s/%s" $username $password $host .Values.connection.port .Values.connection.dbName }}
+  {{- if .Values.connection.schema }}
+  {{- $url = printf "%s?options=-csearch_path%%3D%s" $url .Values.connection.schema }}
+  {{- end }}
+  database_url: "{{ $url | b64enc }}"
   database_password: "{{ $password | b64enc }}"
   google_client_id: "{{ required "auth.googleClientId is required" .Values.auth.googleClientId | b64enc }}"
   google_client_secret: "{{ required "auth.googleClientSecret is required" .Values.auth.googleClientSecret | b64enc }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,6 +22,8 @@ connection:
   port: "5432"
   # -- Name of the database
   dbName: celadon
+  # -- PostgreSQL schema name. When set, appended to DATABASE_URL as `?options=-csearch_path%3D<schema>`.
+  schema: ""
   # -- Username of the database
   username: ""
   # -- Password of the database
@@ -138,6 +140,35 @@ application:
     # -- Port the service exposes
     port: 80
 
+migrator:
+  # -- Enable running yoyo migrations as an initContainer on application pods
+  enabled: true
+  image:
+    # -- The registry to get the migrate image from
+    # @default -- Defaults to `.Values.global.imageRegistry`
+    registry: ""
+    # -- The repository to get your docker image from
+    repository: celadon-migrator
+    # -- What tagged version of the docker image you want deployed
+    # @default -- Defaults to `.Chart.AppVersion`
+    tag: ""
+    # -- What image pull policy do you want?
+    pullPolicy: IfNotPresent
+    # -- List of image pull secrets for the application image
+    # @default -- Merged with `.Values.global.imagePullSecrets`
+    pullSecrets: []
+  resources:
+    requests:
+      # -- Amount of CPU needed for the migrate initContainer
+      cpu: 100m
+      # -- Amount of memory needed for the migrate initContainer
+      memory: 128Mi
+    limits:
+      # -- CPU limit for the migrate initContainer
+      cpu: 250m
+      # -- Memory limit for the migrate initContainer
+      memory: 256Mi
+
 database:
   # -- Enable database
   enabled: true
@@ -154,7 +185,7 @@ database:
     # -- The repository to get your docker image from
     repository: postgres
     # -- What tagged version of the docker image you want deployed
-    tag: "12"
+    tag: "17"
     # -- What image pull policy do you want?
     pullPolicy: IfNotPresent
     # -- List of image pull secrets for the database image
@@ -206,6 +237,11 @@ database:
     type: ClusterIP
     # -- Port the service exposes
     port: 5432
+  # -- Init scripts run by the bundled Postgres on first startup via docker-entrypoint-initdb.d.
+  #    Keys are filenames (alphabetical order controls execution). Values are SQL strings evaluated
+  #    as Helm templates via tpl(), so chart values like .Values.connection.schema resolve at render time.
+  #    Set to {} to skip init scripts entirely.
+  initScripts: {}
 
 auth:
   # -- Google OAuth client ID from Google Cloud Console


### PR DESCRIPTION
Wire `celadon-migrate` into the Helm chart as a `celadon-migrate` initContainer on the app Deployment. The initContainer runs `celadon-migrate apply` on every pod start; yoyo's PG advisory lock serializes concurrent starts safely. Failing migrations surface as `Init:CrashLoopBackOff`, preserving old pods and allowing `helm rollback`.

## What changed

- **`migrator` block in `values.yaml`** — new top-level key controlling the initContainer image, pull policy, and resources
- **`deployment.yaml`** — `initContainers:` added before `containers:`; guarded by `migrator.enabled`; `USER` env var set to satisfy yoyo's `getpass.getuser()` call when running as a UID-only user
- **`secret.yaml`** — `DATABASE_URL` now appends `?options=-csearch_path%3D<schema>` when `connection.schema` is set
- **`values.yaml`** — `connection.schema: ""` (empty by default; set in overrides); postgres image tag corrected to `"17"` (quoted to prevent float rendering); `database.initScripts: {}` — dynamic configmap driven by a `range`+`tpl` pattern, replacing the static `.Files.Get` approach; no SQL files checked in
- **`configmap.yaml`** — iterates `database.initScripts` map and evaluates each value via `tpl()`, allowing Helm template expressions in SQL
- **`Chart.yaml`** — version bumped to `0.6.2`

## Why

Plans 1 (yoyo CLI) and 2 (CI publishing `ghcr.io/hanpeter/celadon-migrate`) are merged. This is the final piece: running migrations automatically on every deploy without Helm hooks, which have a chicken-and-egg problem on fresh installs.

## Smoke tested on minikube

- Fresh install (empty PVC): `0001.initial-schema` applied, all 11 steps committed
- `helm upgrade` with dummy annotation change: `No pending migrations.`
- Pod delete + reschedule: `No pending migrations.`

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] Input validation on all user inputs
- [x] Auth/RBAC checks on protected endpoints
- [x] Error messages don't leak internals
- [ ] GitHub Actions pinned to full commit SHAs (N/A)