### PR TITLE
chore: gitignore .claude/commands for personal skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ dmypy.json
 
 # Personal local dev skills (not for sharing)
 .cursor/skills/
+.claude/commands/
 
 # Local environment variables (contains credentials)
 .envrc


### PR DESCRIPTION
Add `.claude/commands/` to `.gitignore` so personal Claude Code slash commands are not committed.

Moved repo-specific local dev skills (`celadon-deploy`, `celadon-smoke-test`) from `.cursor/skills/` to `.claude/commands/` for use with Claude Code. These are personal, not for sharing.

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] Input validation on all user inputs (N/A)
- [x] Auth/RBAC checks on protected endpoints (N/A)
- [x] Error messages don't leak internals (N/A)
- [x] GitHub Actions pinned to full commit SHAs (N/A)