### PR TITLE
fix(ci): resolve migrate job concurrency deadlock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     permissions: {}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: migrate-${{ github.ref }}
       cancel-in-progress: false
     steps:
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6


### PR DESCRIPTION
## Summary

- The `migrate` job's concurrency group was identical to the top-level workflow concurrency group (`Build-refs/tags/<version>`), causing a GitHub Actions deadlock on every tag push
- Fixed by using a distinct `migrate-${{ github.ref }}` group so the two concurrency blocks no longer compete for the same slot
- The `cancel-in-progress: false` safety guard on the migrate job is preserved

## How tested

Identified via the failed `v0.7.0` run (run ID 26561710440) where GitHub reported: *"Canceling since a deadlock was detected for concurrency group"*. Fix resolves the group collision.

## Checklist

- [x] No security impact
- [ ] Stakeholders notified (N/A — CI-only fix)