### PR TITLE
feat(customer): server-side pagination, search, and sorting

### DIFF
--- a/celadon/application.py
+++ b/celadon/application.py
@@ -63,7 +63,8 @@ class Application:
             raise NotFound(f'Customer {id} not found')
         return customer
 
-    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0, sort_by: str = 'name', sort_dir: str = 'asc') -> tuple[list[Customer], int]:
+    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0,
+                      sort_by: str = 'name', sort_dir: str = 'asc') -> tuple[list[Customer], int]:
         return self._database.get_customers(q=q, limit=limit, offset=offset, sort_by=sort_by, sort_dir=sort_dir)
 
     def add_customer(self, customer: Customer) -> Customer:

--- a/celadon/application.py
+++ b/celadon/application.py
@@ -63,8 +63,8 @@ class Application:
             raise NotFound(f'Customer {id} not found')
         return customer
 
-    def get_customers(self) -> list[Customer]:
-        return self._database.get_customers()
+    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0) -> tuple[list[Customer], int]:
+        return self._database.get_customers(q=q, limit=limit, offset=offset)
 
     def add_customer(self, customer: Customer) -> Customer:
         id = self._database.add_customer(customer)

--- a/celadon/application.py
+++ b/celadon/application.py
@@ -63,8 +63,8 @@ class Application:
             raise NotFound(f'Customer {id} not found')
         return customer
 
-    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0) -> tuple[list[Customer], int]:
-        return self._database.get_customers(q=q, limit=limit, offset=offset)
+    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0, sort_by: str = 'name', sort_dir: str = 'asc') -> tuple[list[Customer], int]:
+        return self._database.get_customers(q=q, limit=limit, offset=offset, sort_by=sort_by, sort_dir=sort_dir)
 
     def add_customer(self, customer: Customer) -> Customer:
         id = self._database.add_customer(customer)

--- a/celadon/db.py
+++ b/celadon/db.py
@@ -86,11 +86,18 @@ class Database:
             with conn.cursor() as cur:
                 cur.execute(Item.UPDATE, item.model_dump())
 
-    def get_customers(self):
+    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0) -> tuple[list[Customer], int]:
+        escaped = q.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+        search_params = {'q': q, 'pattern': f'%{escaped}%'}
+        page_params = {**search_params, 'limit': limit, 'offset': offset}
         with self._pool.connection() as conn:
             with conn.cursor(row_factory=dict_row) as cur:
-                cur.execute(Customer.SELECT_ALL)
-                return [Customer.model_validate(row) for row in cur]
+                cur.execute(Customer.SEARCH_PAGE, page_params)
+                items = [Customer.model_validate(row) for row in cur]
+            with conn.cursor() as cur:
+                cur.execute(Customer.SEARCH_COUNT, search_params)
+                total = cur.fetchone()[0]
+        return items, total
 
     def get_customer(self, id):
         with self._pool.connection() as conn:

--- a/celadon/db.py
+++ b/celadon/db.py
@@ -86,13 +86,14 @@ class Database:
             with conn.cursor() as cur:
                 cur.execute(Item.UPDATE, item.model_dump())
 
-    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0) -> tuple[list[Customer], int]:
+    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0, sort_by: str = 'name', sort_dir: str = 'asc') -> tuple[list[Customer], int]:
         escaped = q.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
         search_params = {'q': q, 'pattern': f'%{escaped}%'}
         page_params = {**search_params, 'limit': limit, 'offset': offset}
+        page_query = Customer.SEARCH_PAGE.format(sort_col=sort_by, sort_dir=sort_dir.upper())
         with self._pool.connection() as conn:
             with conn.cursor(row_factory=dict_row) as cur:
-                cur.execute(Customer.SEARCH_PAGE, page_params)
+                cur.execute(page_query, page_params)
                 items = [Customer.model_validate(row) for row in cur]
             with conn.cursor() as cur:
                 cur.execute(Customer.SEARCH_COUNT, search_params)

--- a/celadon/db.py
+++ b/celadon/db.py
@@ -86,7 +86,8 @@ class Database:
             with conn.cursor() as cur:
                 cur.execute(Item.UPDATE, item.model_dump())
 
-    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0, sort_by: str = 'name', sort_dir: str = 'asc') -> tuple[list[Customer], int]:
+    def get_customers(self, q: str = '', limit: int = 20, offset: int = 0,
+                      sort_by: str = 'name', sort_dir: str = 'asc') -> tuple[list[Customer], int]:
         escaped = q.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
         search_params = {'q': q, 'pattern': f'%{escaped}%'}
         page_params = {**search_params, 'limit': limit, 'offset': offset}

--- a/celadon/models/customer.py
+++ b/celadon/models/customer.py
@@ -8,12 +8,29 @@ from celadon.models.validator import OptionalText
 
 class Customer(BaseModel):
     model_config = ConfigDict(extra='forbid')
-    SELECT_ALL: ClassVar[str] = dedent('''\
-        SELECT id, name, nickname, phone_number, address, postal_code,
-               personal_customs_clearance_code
-        FROM customers
-    ''')
-    SELECT_ONE: ClassVar[str] = SELECT_ALL.rstrip() + ' WHERE id = %s\n'
+
+    _SELECT_COLUMNS: ClassVar[str] = (
+        'id, name, nickname, phone_number, address, postal_code, '
+        'personal_customs_clearance_code'
+    )
+    SEARCHABLE_COLUMNS: ClassVar[tuple[str, ...]] = (
+        'name', 'nickname', 'phone_number', 'address', 'postal_code',
+        'personal_customs_clearance_code',
+    )
+    _SEARCH_WHERE: ClassVar[str] = (
+        "WHERE (%(q)s = '' OR "
+        + ' OR '.join(f'{col} ILIKE %(pattern)s' for col in SEARCHABLE_COLUMNS)
+        + ')'
+    )
+    _PAGE_TAIL: ClassVar[str] = 'ORDER BY name ASC LIMIT %(limit)s OFFSET %(offset)s'
+
+    SELECT_ONE: ClassVar[str] = (
+        f'SELECT {_SELECT_COLUMNS} FROM customers WHERE id = %s\n'
+    )
+    SEARCH_PAGE: ClassVar[str] = (
+        f'SELECT {_SELECT_COLUMNS} FROM customers {_SEARCH_WHERE} {_PAGE_TAIL}'
+    )
+    SEARCH_COUNT: ClassVar[str] = f'SELECT COUNT(*) FROM customers {_SEARCH_WHERE}'
     INSERT: ClassVar[str] = dedent('''\
         INSERT INTO customers
             (name, nickname, phone_number, address, postal_code,

--- a/celadon/models/customer.py
+++ b/celadon/models/customer.py
@@ -13,16 +13,16 @@ class Customer(BaseModel):
         'id, name, nickname, phone_number, address, postal_code, '
         'personal_customs_clearance_code'
     )
-    SEARCHABLE_COLUMNS: ClassVar[tuple[str, ...]] = (
+    TEXT_COLUMNS: ClassVar[tuple[str, ...]] = (
         'name', 'nickname', 'phone_number', 'address', 'postal_code',
         'personal_customs_clearance_code',
     )
     _SEARCH_WHERE: ClassVar[str] = (
         "WHERE (%(q)s = '' OR "
-        + ' OR '.join(f'{col} ILIKE %(pattern)s' for col in SEARCHABLE_COLUMNS)
+        + ' OR '.join(f'{col} ILIKE %(pattern)s' for col in TEXT_COLUMNS)
         + ')'
     )
-    _PAGE_TAIL: ClassVar[str] = 'ORDER BY name ASC LIMIT %(limit)s OFFSET %(offset)s'
+    _PAGE_TAIL: ClassVar[str] = 'ORDER BY {sort_col} {sort_dir} LIMIT %(limit)s OFFSET %(offset)s'
 
     SELECT_ONE: ClassVar[str] = (
         f'SELECT {_SELECT_COLUMNS} FROM customers WHERE id = %s\n'

--- a/celadon/server.py
+++ b/celadon/server.py
@@ -79,6 +79,22 @@ def _parse_bounded_int(name: str, raw: str | None, *, default: int, lo: int, hi:
     return value
 
 
+def _parse_sort_by(raw: str | None, valid_cols: tuple[str, ...], default: str) -> str:
+    if raw is None:
+        return default
+    if raw not in valid_cols:
+        raise BadRequest(f"'sort_by' must be one of: {', '.join(sorted(valid_cols))}")
+    return raw
+
+
+def _parse_sort_dir(raw: str | None) -> str:
+    if raw is None:
+        return 'asc'
+    if raw.lower() not in ('asc', 'desc'):
+        raise BadRequest("'sort_dir' must be 'asc' or 'desc'")
+    return raw.lower()
+
+
 def _check_server_fields(body: dict, *field_sets: frozenset[str]) -> None:
     server_fields = frozenset().union(*field_sets)
     sent = server_fields & body.keys()
@@ -149,7 +165,9 @@ def customer(customer_id=None):
             q = request.args.get('q', '').strip()
             limit = _parse_bounded_int('limit', request.args.get('limit'), default=20, lo=1, hi=1000)
             offset = _parse_bounded_int('offset', request.args.get('offset'), default=0, lo=0, hi=2_147_483_647)
-            items, total = server.app.get_customers(q=q, limit=limit, offset=offset)
+            sort_by = _parse_sort_by(request.args.get('sort_by'), Customer.TEXT_COLUMNS, 'name')
+            sort_dir = _parse_sort_dir(request.args.get('sort_dir'))
+            items, total = server.app.get_customers(q=q, limit=limit, offset=offset, sort_by=sort_by, sort_dir=sort_dir)
             return jsonify({'items': [c.model_dump(mode='json') for c in items], 'total': total})
     else:
         if request.method == 'PUT':

--- a/celadon/server.py
+++ b/celadon/server.py
@@ -68,6 +68,17 @@ def get_request_json() -> dict:
     return body
 
 
+def _parse_bounded_int(name: str, raw: str | None, *, default: int, lo: int, hi: int) -> int:
+    if raw is None:
+        return default
+    if not raw.lstrip('-').isdigit():
+        raise BadRequest(f"'{name}' must be an integer")
+    value = int(raw)
+    if not (lo <= value <= hi):
+        raise BadRequest(f"'{name}' must be between {lo} and {hi}")
+    return value
+
+
 def _check_server_fields(body: dict, *field_sets: frozenset[str]) -> None:
     server_fields = frozenset().union(*field_sets)
     sent = server_fields & body.keys()
@@ -135,7 +146,11 @@ def customer(customer_id=None):
             model = Customer.model_validate(get_request_json())
             return jsonify(server.app.add_customer(model).model_dump(mode='json')), 201
         else:
-            return jsonify([c.model_dump(mode='json') for c in server.app.get_customers()])
+            q = request.args.get('q', '').strip()
+            limit = _parse_bounded_int('limit', request.args.get('limit'), default=20, lo=1, hi=1000)
+            offset = _parse_bounded_int('offset', request.args.get('offset'), default=0, lo=0, hi=2_147_483_647)
+            items, total = server.app.get_customers(q=q, limit=limit, offset=offset)
+            return jsonify({'items': [c.model_dump(mode='json') for c in items], 'total': total})
     else:
         if request.method == 'PUT':
             model = Customer.model_validate({**get_request_json(), 'id': customer_id})

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -21,11 +21,13 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
   return res.json() as Promise<T>;
 }
 
-export const getCustomers = (params: { q?: string; limit?: number; offset?: number } = {}) => {
+export const getCustomers = (params: { q?: string; limit?: number; offset?: number; sort_by?: string; sort_dir?: 'asc' | 'desc' } = {}) => {
   const qs = new URLSearchParams();
   if (params.q) qs.set('q', params.q);
   if (params.limit !== undefined) qs.set('limit', String(params.limit));
   if (params.offset !== undefined) qs.set('offset', String(params.offset));
+  if (params.sort_by) qs.set('sort_by', params.sort_by);
+  if (params.sort_dir) qs.set('sort_dir', params.sort_dir);
   const query = qs.toString();
   return request<{ items: Customer[]; total: number }>('GET', query ? `/customer?${query}` : '/customer');
 };

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -21,7 +21,14 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
   return res.json() as Promise<T>;
 }
 
-export const getCustomers = () => request<Customer[]>('GET', '/customer');
+export const getCustomers = (params: { q?: string; limit?: number; offset?: number } = {}) => {
+  const qs = new URLSearchParams();
+  if (params.q) qs.set('q', params.q);
+  if (params.limit !== undefined) qs.set('limit', String(params.limit));
+  if (params.offset !== undefined) qs.set('offset', String(params.offset));
+  const query = qs.toString();
+  return request<{ items: Customer[]; total: number }>('GET', query ? `/customer?${query}` : '/customer');
+};
 export const createCustomer = (data: Record<string, unknown>) =>
   request<Customer>('POST', '/customer', data);
 export const updateCustomer = (id: number, data: Record<string, unknown>) =>

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Table,
   Button,
@@ -10,7 +10,6 @@ import {
   ToastContainer,
 } from 'react-bootstrap';
 import { getCustomers, createCustomer, updateCustomer } from '../api';
-import { useLoad } from '../hooks/useLoad';
 import type { Customer } from '../types';
 
 const PAGE_SIZE = 20;
@@ -32,8 +31,6 @@ const COLUMNS: Column[] = [
   { field: 'personal_customs_clearance_code', label: 'Customs Code' },
 ];
 
-type SortDir = 'asc' | 'desc';
-
 interface ToastItem {
   id: string;
   message: string;
@@ -44,10 +41,15 @@ interface ToastItem {
 const TABLET_COLSPAN = 1 + COLUMNS.filter((c) => c.tablet !== false).length;
 
 export default function CustomersPage() {
-  const { data: customers, loading, error, load } = useLoad(getCustomers);
-  const [sortField, setSortField] = useState<keyof Customer | null>(null);
-  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const [q, setQ] = useState('');
+  const [debouncedQ, setDebouncedQ] = useState('');
   const [page, setPage] = useState(1);
+  const [items, setItems] = useState<Customer[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
   const [showModal, setShowModal] = useState(false);
   const [showViewModal, setShowViewModal] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -58,39 +60,37 @@ export default function CustomersPage() {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
 
+  // Debounce: flush q → debouncedQ after 300ms of inactivity; reset page on new query
   useEffect(() => {
-    load();
-  }, [load]);
+    const t = setTimeout(() => {
+      setDebouncedQ(q);
+      setPage(1);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [q]);
 
-  const sortedCustomers = useCallback(() => {
-    if (!customers) return [];
-    const list = [...customers];
-    if (!sortField) return list;
-    return list.sort((a, b) => {
-      const av = a[sortField] ?? '';
-      const bv = b[sortField] ?? '';
-      const cmp = String(av).localeCompare(String(bv), undefined, {
-        numeric: true,
-        sensitivity: 'base',
+  // Fetch from server whenever query, page, or refreshKey changes
+  useEffect(() => {
+    let ignore = false;
+    setLoading(true);
+    setError(null);
+    getCustomers({ q: debouncedQ, limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE })
+      .then(({ items: fetched, total: fetchedTotal }) => {
+        if (!ignore) {
+          setItems(fetched);
+          setTotal(fetchedTotal);
+        }
+      })
+      .catch((err) => {
+        if (!ignore) setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!ignore) setLoading(false);
       });
-      return sortDir === 'asc' ? cmp : -cmp;
-    });
-  }, [customers, sortField, sortDir]);
+    return () => { ignore = true; };
+  }, [debouncedQ, page, refreshKey]);
 
-  const sorted = sortedCustomers();
-  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
-  const start = (page - 1) * PAGE_SIZE;
-  const pageCustomers = sorted.slice(start, start + PAGE_SIZE);
-
-  const handleSort = (field: keyof Customer) => {
-    if (sortField === field) {
-      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
-    } else {
-      setSortField(field);
-      setSortDir('asc');
-    }
-    setPage(1);
-  };
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
   const openAddModal = () => {
     setEditingId(null);
@@ -100,7 +100,7 @@ export default function CustomersPage() {
   };
 
   const openEditModal = (id: number) => {
-    const customer = customers?.find((c) => c.id === id);
+    const customer = items.find((c) => c.id === id);
     if (!customer) return;
     setEditingId(id);
     const data: Record<string, string> = {};
@@ -135,7 +135,7 @@ export default function CustomersPage() {
         showToast('Customer added.', 'success');
       }
       setShowModal(false);
-      await load();
+      setRefreshKey((k) => k + 1);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setModalError(msg);
@@ -160,39 +160,40 @@ export default function CustomersPage() {
     });
   };
 
-  const viewingCustomer = customers?.find((c) => c.id === viewingId);
-
-  const sortIcon = (field: keyof Customer) => {
-    if (sortField !== field) return <span className="sort-icon text-muted">⇅</span>;
-    return sortDir === 'asc' ? (
-      <span className="sort-icon">↑</span>
-    ) : (
-      <span className="sort-icon">↓</span>
-    );
-  };
+  const viewingCustomer = items.find((c) => c.id === viewingId);
 
   return (
     <>
       <div className="d-flex justify-content-between align-items-center mb-3">
         <h4 className="mb-0">Customers</h4>
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={openAddModal}
-          className="d-flex align-items-center gap-2"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            fill="currentColor"
-            className="bi bi-plus-lg"
-            viewBox="0 0 16 16"
+        <div className="d-flex align-items-center gap-2">
+          <Form.Control
+            type="search"
+            placeholder="Search customers…"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            style={{ width: '200px' }}
+            size="sm"
+          />
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={openAddModal}
+            className="d-flex align-items-center gap-2"
           >
-            <path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2" />
-          </svg>
-          Add Customer
-        </Button>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="currentColor"
+              className="bi bi-plus-lg"
+              viewBox="0 0 16 16"
+            >
+              <path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2" />
+            </svg>
+            Add Customer
+          </Button>
+        </div>
       </div>
 
       {error && (
@@ -204,8 +205,10 @@ export default function CustomersPage() {
       <div className="table-responsive">
         {loading ? (
           <div className="text-center text-muted py-4">Loading…</div>
-        ) : !customers || customers.length === 0 ? (
-          <div className="text-center text-muted py-4">No customers found.</div>
+        ) : items.length === 0 ? (
+          <div className="text-center text-muted py-4">
+            {debouncedQ ? 'No customers match your search.' : 'No customers found.'}
+          </div>
         ) : (
           <Table hover className="align-middle" id="customer-table">
             <thead className="table-light">
@@ -219,17 +222,9 @@ export default function CustomersPage() {
                   <th
                     key={field}
                     scope="col"
-                    className={`sortable-col${
-                      tablet === false ? ' col-desktop-only' : ''
-                    }`}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => handleSort(field)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') handleSort(field);
-                    }}
+                    className={tablet === false ? 'col-desktop-only' : ''}
                   >
-                    {label} {sortIcon(field)}
+                    {label}
                   </th>
                 ))}
                 {/* Desktop actions column — CSS shows at lg+ */}
@@ -239,7 +234,7 @@ export default function CustomersPage() {
               </tr>
             </thead>
             <tbody>
-              {pageCustomers.map((customer) => (
+              {items.map((customer) => (
                 <React.Fragment key={customer.id}>
                   <tr
                     data-id={customer.id}

--- a/frontend/src/pages/CustomersPage.tsx
+++ b/frontend/src/pages/CustomersPage.tsx
@@ -13,6 +13,7 @@ import { getCustomers, createCustomer, updateCustomer } from '../api';
 import type { Customer } from '../types';
 
 const PAGE_SIZE = 20;
+type SortDir = 'asc' | 'desc';
 
 interface Column {
   field: keyof Customer;
@@ -44,6 +45,8 @@ export default function CustomersPage() {
   const [q, setQ] = useState('');
   const [debouncedQ, setDebouncedQ] = useState('');
   const [page, setPage] = useState(1);
+  const [sortField, setSortField] = useState<keyof Customer>('name');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [items, setItems] = useState<Customer[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -74,7 +77,7 @@ export default function CustomersPage() {
     let ignore = false;
     setLoading(true);
     setError(null);
-    getCustomers({ q: debouncedQ, limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE })
+    getCustomers({ q: debouncedQ, limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE, sort_by: sortField, sort_dir: sortDir })
       .then(({ items: fetched, total: fetchedTotal }) => {
         if (!ignore) {
           setItems(fetched);
@@ -88,9 +91,26 @@ export default function CustomersPage() {
         if (!ignore) setLoading(false);
       });
     return () => { ignore = true; };
-  }, [debouncedQ, page, refreshKey]);
+  }, [debouncedQ, page, sortField, sortDir, refreshKey]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const handleSort = (field: keyof Customer) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+    setPage(1);
+  };
+
+  const sortIcon = (field: keyof Customer) => {
+    if (sortField !== field) return <span className="sort-icon text-muted">⇅</span>;
+    return sortDir === 'asc'
+      ? <span className="sort-icon">↑</span>
+      : <span className="sort-icon">↓</span>;
+  };
 
   const openAddModal = () => {
     setEditingId(null);
@@ -222,9 +242,15 @@ export default function CustomersPage() {
                   <th
                     key={field}
                     scope="col"
-                    className={tablet === false ? 'col-desktop-only' : ''}
+                    className={`sortable-col${tablet === false ? ' col-desktop-only' : ''}`}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => handleSort(field)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') handleSort(field);
+                    }}
                   >
-                    {label}
+                    {label} {sortIcon(field)}
                   </th>
                 ))}
                 {/* Desktop actions column — CSS shows at lg+ */}

--- a/frontend/src/pages/SalesPage.tsx
+++ b/frontend/src/pages/SalesPage.tsx
@@ -39,7 +39,7 @@ interface Toast {
 
 export default function SalesPage() {
   const salesLoad = useLoad(() => getSales());
-  const customersLoad = useLoad(() => getCustomers());
+  const customersLoad = useLoad(() => getCustomers().then((r) => r.items));
 
   const [sortField, setSortField] = useState<keyof Sale>('sales_date');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -156,12 +156,55 @@ class TestCustomer:
                 'phone_number': '010-1234-5678', 'address': '123 Main St',
                 'postal_code': '12345', 'personal_customs_clearance_code': 'P123'}
 
-    def test_get_customers(self, db_instance, mock_conn):
-        cur = _make_cursor(rows=[self._make_row()])
-        mock_conn.cursor.return_value = cur
-        result = db_instance.get_customers()
-        cur.execute.assert_called_once_with(Customer.SELECT_ALL)
-        assert isinstance(result[0], Customer)
+    def test_get_customers_default(self, db_instance, mock_conn):
+        row = self._make_row()
+        page_cur = _make_cursor(rows=[row])
+        count_cur = _make_cursor(fetchone_value=1)
+        mock_conn.cursor.side_effect = [page_cur, count_cur]
+        items, total = db_instance.get_customers()
+        page_params = {'q': '', 'pattern': '%%', 'limit': 20, 'offset': 0}
+        count_params = {'q': '', 'pattern': '%%'}
+        page_cur.execute.assert_called_once_with(Customer.SEARCH_PAGE, page_params)
+        count_cur.execute.assert_called_once_with(Customer.SEARCH_COUNT, count_params)
+        assert total == 1
+        assert isinstance(items[0], Customer)
+
+    def test_get_customers_search(self, db_instance, mock_conn):
+        row = self._make_row()
+        page_cur = _make_cursor(rows=[row])
+        count_cur = _make_cursor(fetchone_value=1)
+        mock_conn.cursor.side_effect = [page_cur, count_cur]
+        items, total = db_instance.get_customers(q='alice', limit=10, offset=0)
+        page_params = {'q': 'alice', 'pattern': '%alice%', 'limit': 10, 'offset': 0}
+        count_params = {'q': 'alice', 'pattern': '%alice%'}
+        page_cur.execute.assert_called_once_with(Customer.SEARCH_PAGE, page_params)
+        count_cur.execute.assert_called_once_with(Customer.SEARCH_COUNT, count_params)
+        assert total == 1
+        assert items[0].name == 'Alice'
+
+    def test_get_customers_escapes_special_chars(self, db_instance, mock_conn):
+        page_cur = _make_cursor(rows=[])
+        count_cur = _make_cursor(fetchone_value=0)
+        mock_conn.cursor.side_effect = [page_cur, count_cur]
+        db_instance.get_customers(q='50%_off\\sale')
+        page_params = page_cur.execute.call_args[0][1]
+        assert page_params['pattern'] == '%50\\%\\_off\\\\sale%'
+
+    def test_get_customers_escapes_bare_backslash(self, db_instance, mock_conn):
+        page_cur = _make_cursor(rows=[])
+        count_cur = _make_cursor(fetchone_value=0)
+        mock_conn.cursor.side_effect = [page_cur, count_cur]
+        db_instance.get_customers(q='\\')
+        page_params = page_cur.execute.call_args[0][1]
+        assert page_params['pattern'] == '%\\\\%'
+
+    def test_get_customers_escapes_backslash_before_percent(self, db_instance, mock_conn):
+        page_cur = _make_cursor(rows=[])
+        count_cur = _make_cursor(fetchone_value=0)
+        mock_conn.cursor.side_effect = [page_cur, count_cur]
+        db_instance.get_customers(q='test\\%pattern')
+        page_params = page_cur.execute.call_args[0][1]
+        assert page_params['pattern'] == '%test\\\\\\%pattern%'
 
     def test_get_customer(self, db_instance, mock_conn):
         row = self._make_row()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -164,7 +164,7 @@ class TestCustomer:
         items, total = db_instance.get_customers()
         page_params = {'q': '', 'pattern': '%%', 'limit': 20, 'offset': 0}
         count_params = {'q': '', 'pattern': '%%'}
-        page_cur.execute.assert_called_once_with(Customer.SEARCH_PAGE, page_params)
+        page_cur.execute.assert_called_once_with(Customer.SEARCH_PAGE.format(sort_col='name', sort_dir='ASC'), page_params)
         count_cur.execute.assert_called_once_with(Customer.SEARCH_COUNT, count_params)
         assert total == 1
         assert isinstance(items[0], Customer)
@@ -177,7 +177,7 @@ class TestCustomer:
         items, total = db_instance.get_customers(q='alice', limit=10, offset=0)
         page_params = {'q': 'alice', 'pattern': '%alice%', 'limit': 10, 'offset': 0}
         count_params = {'q': 'alice', 'pattern': '%alice%'}
-        page_cur.execute.assert_called_once_with(Customer.SEARCH_PAGE, page_params)
+        page_cur.execute.assert_called_once_with(Customer.SEARCH_PAGE.format(sort_col='name', sort_dir='ASC'), page_params)
         count_cur.execute.assert_called_once_with(Customer.SEARCH_COUNT, count_params)
         assert total == 1
         assert items[0].name == 'Alice'
@@ -189,6 +189,14 @@ class TestCustomer:
         db_instance.get_customers(q='50%_off\\sale')
         page_params = page_cur.execute.call_args[0][1]
         assert page_params['pattern'] == '%50\\%\\_off\\\\sale%'
+
+    def test_get_customers_sort(self, db_instance, mock_conn):
+        page_cur = _make_cursor(rows=[self._make_row()])
+        count_cur = _make_cursor(fetchone_value=1)
+        mock_conn.cursor.side_effect = [page_cur, count_cur]
+        db_instance.get_customers(sort_by='nickname', sort_dir='desc')
+        executed_sql = page_cur.execute.call_args[0][0]
+        assert 'nickname DESC' in executed_sql
 
     def test_get_customers_escapes_bare_backslash(self, db_instance, mock_conn):
         page_cur = _make_cursor(rows=[])

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -164,7 +164,8 @@ class TestCustomer:
         items, total = db_instance.get_customers()
         page_params = {'q': '', 'pattern': '%%', 'limit': 20, 'offset': 0}
         count_params = {'q': '', 'pattern': '%%'}
-        page_cur.execute.assert_called_once_with(Customer.SEARCH_PAGE.format(sort_col='name', sort_dir='ASC'), page_params)
+        expected_sql = Customer.SEARCH_PAGE.format(sort_col='name', sort_dir='ASC')
+        page_cur.execute.assert_called_once_with(expected_sql, page_params)
         count_cur.execute.assert_called_once_with(Customer.SEARCH_COUNT, count_params)
         assert total == 1
         assert isinstance(items[0], Customer)
@@ -177,7 +178,8 @@ class TestCustomer:
         items, total = db_instance.get_customers(q='alice', limit=10, offset=0)
         page_params = {'q': 'alice', 'pattern': '%alice%', 'limit': 10, 'offset': 0}
         count_params = {'q': 'alice', 'pattern': '%alice%'}
-        page_cur.execute.assert_called_once_with(Customer.SEARCH_PAGE.format(sort_col='name', sort_dir='ASC'), page_params)
+        expected_sql = Customer.SEARCH_PAGE.format(sort_col='name', sort_dir='ASC')
+        page_cur.execute.assert_called_once_with(expected_sql, page_params)
         count_cur.execute.assert_called_once_with(Customer.SEARCH_COUNT, count_params)
         assert total == 1
         assert items[0].name == 'Alice'

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from click.testing import CliRunner
 from unittest.mock import MagicMock, patch
@@ -36,7 +37,9 @@ def _invoke(runner, mig_dir, db_url, *args):
 
 
 def test_missing_database_url(runner, mig_dir):
-    result = runner.invoke(main, ["--migrations-dir", str(mig_dir), "apply"])
+    with patch.dict(os.environ):
+        os.environ.pop('DATABASE_URL', None)
+        result = runner.invoke(main, ["--migrations-dir", str(mig_dir), "apply"])
     assert result.exit_code != 0
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -271,7 +271,7 @@ class TestCustomerRoutes:
         data = r.get_json()
         assert data["items"][0]["id"] == 1
         assert data["total"] == 1
-        mock_app.get_customers.assert_called_once_with(q='', limit=20, offset=0)
+        mock_app.get_customers.assert_called_once_with(q='', limit=20, offset=0, sort_by='name', sort_dir='asc')
 
     def test_get_list_with_search(self, flask_client):
         _, mock_app = flask_client
@@ -281,7 +281,7 @@ class TestCustomerRoutes:
             with _authed_client() as client:
                 r = client.get("/customer?q=alice")
         assert r.status_code == 200
-        mock_app.get_customers.assert_called_once_with(q='alice', limit=20, offset=0)
+        mock_app.get_customers.assert_called_once_with(q='alice', limit=20, offset=0, sort_by='name', sort_dir='asc')
 
     def test_get_list_with_pagination(self, flask_client):
         _, mock_app = flask_client
@@ -290,7 +290,7 @@ class TestCustomerRoutes:
             with _authed_client() as client:
                 r = client.get("/customer?limit=50&offset=100")
         assert r.status_code == 200
-        mock_app.get_customers.assert_called_once_with(q='', limit=50, offset=100)
+        mock_app.get_customers.assert_called_once_with(q='', limit=50, offset=100, sort_by='name', sort_dir='asc')
 
     def test_get_list_limit_max(self, flask_client):
         _, mock_app = flask_client
@@ -299,7 +299,46 @@ class TestCustomerRoutes:
             with _authed_client() as client:
                 r = client.get("/customer?limit=1000")
         assert r.status_code == 200
-        mock_app.get_customers.assert_called_once_with(q='', limit=1000, offset=0)
+        mock_app.get_customers.assert_called_once_with(q='', limit=1000, offset=0, sort_by='name', sort_dir='asc')
+
+    def test_get_list_sort_valid(self, flask_client):
+        _, mock_app = flask_client
+        mock_app.get_customers.return_value = ([], 0)
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?sort_by=nickname&sort_dir=desc")
+        assert r.status_code == 200
+        mock_app.get_customers.assert_called_once_with(q='', limit=20, offset=0, sort_by='nickname', sort_dir='desc')
+
+    def test_get_list_sort_dir_case_insensitive(self, flask_client):
+        _, mock_app = flask_client
+        mock_app.get_customers.return_value = ([], 0)
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?sort_dir=DESC")
+        assert r.status_code == 200
+        mock_app.get_customers.assert_called_once_with(q='', limit=20, offset=0, sort_by='name', sort_dir='desc')
+
+    def test_get_list_sort_by_invalid(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?sort_by=invalid_col")
+        assert r.status_code == 400
+
+    def test_get_list_sort_by_id_rejected(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?sort_by=id")
+        assert r.status_code == 400
+
+    def test_get_list_sort_dir_invalid(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?sort_dir=diagonal")
+        assert r.status_code == 400
 
     def test_get_list_limit_too_large(self, flask_client):
         _, mock_app = flask_client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -260,16 +260,124 @@ class TestPurchaseRoutes:
 
 
 class TestCustomerRoutes:
-    def test_get_list(self, flask_client):
+    def test_get_list_default_params(self, flask_client):
         _, mock_app = flask_client
         models = [Customer(id=1, name='c')]
-        mock_app.get_customers.return_value = models
+        mock_app.get_customers.return_value = (models, 1)
         with patch("celadon.server.server.app", mock_app):
             with _authed_client() as client:
                 r = client.get("/customer")
         assert r.status_code == 200
-        assert r.get_json()[0]["id"] == 1
-        mock_app.get_customers.assert_called_once_with()
+        data = r.get_json()
+        assert data["items"][0]["id"] == 1
+        assert data["total"] == 1
+        mock_app.get_customers.assert_called_once_with(q='', limit=20, offset=0)
+
+    def test_get_list_with_search(self, flask_client):
+        _, mock_app = flask_client
+        models = [Customer(id=2, name='alice')]
+        mock_app.get_customers.return_value = (models, 1)
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?q=alice")
+        assert r.status_code == 200
+        mock_app.get_customers.assert_called_once_with(q='alice', limit=20, offset=0)
+
+    def test_get_list_with_pagination(self, flask_client):
+        _, mock_app = flask_client
+        mock_app.get_customers.return_value = ([], 100)
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=50&offset=100")
+        assert r.status_code == 200
+        mock_app.get_customers.assert_called_once_with(q='', limit=50, offset=100)
+
+    def test_get_list_limit_max(self, flask_client):
+        _, mock_app = flask_client
+        mock_app.get_customers.return_value = ([], 0)
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=1000")
+        assert r.status_code == 200
+        mock_app.get_customers.assert_called_once_with(q='', limit=1000, offset=0)
+
+    def test_get_list_limit_too_large(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=1001")
+        assert r.status_code == 400
+
+    def test_get_list_limit_zero(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=0")
+        assert r.status_code == 400
+
+    def test_get_list_limit_negative(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=-1")
+        assert r.status_code == 400
+
+    def test_get_list_limit_non_integer(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=abc")
+        assert r.status_code == 400
+
+    def test_get_list_limit_float(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=1.5")
+        assert r.status_code == 400
+
+    def test_get_list_offset_negative(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?offset=-1")
+        assert r.status_code == 400
+
+    def test_get_list_offset_non_integer(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?offset=abc")
+        assert r.status_code == 400
+
+    def test_get_list_limit_with_leading_space(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit= 50")
+        assert r.status_code == 400
+
+    def test_get_list_limit_with_trailing_space(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=50 ")
+        assert r.status_code == 400
+
+    def test_get_list_limit_scientific_notation(self, flask_client):
+        _, mock_app = flask_client
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=1e3")
+        assert r.status_code == 400
+
+    def test_get_list_limit_negative_zero(self, flask_client):
+        _, mock_app = flask_client
+        mock_app.get_customers.return_value = ([], 0)
+        with patch("celadon.server.server.app", mock_app):
+            with _authed_client() as client:
+                r = client.get("/customer?limit=-0")
+        assert r.status_code == 400
 
     def test_post_valid_json(self, flask_client):
         _, mock_app = flask_client


### PR DESCRIPTION
Add server-side pagination, free-text search, and column sorting to the customer list endpoint.

Previously the frontend fetched every customer on load and paginated/sorted client-side. As the customer list grows this wastes bandwidth and makes search impossible without loading everything first.

## What changed

**API** — `GET /customer` now accepts:
- `q` — case-insensitive substring search across all text columns (ILIKE, with `%`, `_`, `\` escaping)
- `limit` — page size, `[1, 1000]`, default 20; strict integer validation, 400 on bad input
- `offset` — default 0, must be `>= 0`; strict integer validation, 400 on bad input
- `sort_by` — any column in `Customer.TEXT_COLUMNS`, default `name`; 400 on unknown column
- `sort_dir` — `asc` or `desc` (case-insensitive), default `asc`; 400 on invalid value

Response shape changed from `Customer[]` to `{ items: Customer[], total: number }`.

**SQL** — `Customer.TEXT_COLUMNS` is the single source of truth for which columns participate in search and sort. `SEARCH_PAGE` and `SEARCH_COUNT` are composed from shared fragments (`_SELECT_COLUMNS`, `_SEARCH_WHERE`, `_PAGE_TAIL`) so the WHERE clause is never duplicated. `SELECT_ALL` is removed — all reads go through the paginated path.

**Frontend** — debounced live search (300ms, stale-response ignore flag), server-driven pagination, clickable sort headers with `↑`/`↓` icons. `SalesPage` updated to unwrap `.items` from the new response shape.

**Tests** — boundary cases for `limit`/`offset` (zero, negative, float, scientific notation, leading whitespace), `sort_by`/`sort_dir` validation, LIKE escape edge cases (bare backslash, `\%` sequence). Pre-existing `test_missing_database_url` fixed: `conftest.py` sets `DATABASE_URL` via `setdefault`, masking the missing-option check; now uses `patch.dict` to unset it for that test.

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] Input validation on all user inputs (`sort_by` validated against an allowlist — no SQL injection via column name; `sort_dir` restricted to `asc`/`desc`)
- [x] Auth/RBAC checks on protected endpoints (login-required unchanged)
- [x] Error messages don't leak internals
- [ ] GitHub Actions pinned to full commit SHAs (N/A — no workflow changes)