### PR TITLE
chore(deps): Add npm dependabot and fix helm directory scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
       prefix: "chore"
       include: "scope"
   - package-ecosystem: "helm"
-    directory: "/"
+    directories:
+      - "/**"
     schedule:
       interval: "weekly"
     commit-message:
@@ -16,6 +17,14 @@ updates:
       include: "scope"
   - package-ecosystem: "pip"
     directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+  - package-ecosystem: "npm"
+    directories:
+      - "/**"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
Add Dependabot coverage for npm dependencies and fix the helm ecosystem configuration.

Two changes:

1. **New: npm ecosystem** — tracks `frontend/package.json` (added in #71 when the frontend migrated to React + TypeScript). Uses `directories: ["/**"]` to scan the whole repo rather than hard-coding a path.

2. **Fix: helm ecosystem** — `Chart.yaml` lives at `helm/Chart.yaml`, not the repo root, so `directory: "/"` was never finding it. Switched to `directories: ["/**"]` so Dependabot actually scans subdirectories.

`github-actions` and `pip` are left as `directory: "/"` — their manifests are at the repo root, so no change needed.

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] Input validation on all user inputs
- [x] Auth/RBAC checks on protected endpoints
- [x] Error messages don't leak internals
- [x] GitHub Actions pinned to full commit SHAs (N/A — config-only change)