### PR TITLE
chore(deps): bump react-router from 7 to 8 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "react": "^19.2.6",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.6",
-        "react-router": "^7.15.1"
+        "react-router": "^8.0.1"
       },
       "devDependencies": {
         "@types/react": "^19.2.15",
@@ -625,18 +625,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1193,20 +1186,19 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.0.1.tgz",
+      "integrity": "sha512-5EL/fANovVUhRK50NLS8RYfX0BxrimoKsHWUPPy8v5UEl8i6vzF7e4POo3u+AhPItDwccUAJjMfIOmydxBJmQw==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -1285,12 +1277,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "react": "^19.2.6",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.6",
-    "react-router": "^7.15.1"
+    "react-router": "^8.0.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.15",


### PR DESCRIPTION
Bump `react-router` from 7.17.0 to 8.0.1 in `/frontend`.

Replaces the failed Dependabot rebase on PR #84 with a clean branch off current `main`.

## Why this is safe

The app uses only the stable declarative API (`HashRouter`, `Routes`, `Route`, `NavLink`) imported directly from `react-router` — none of the removed or moved exports from v8:

- `react-router-dom` removed in v8 → not used (imports already from `react-router`)
- `RouterProvider`/data-router middleware changes → not used (app uses `<HashRouter>` component mode)
- Min React ≥ 19.2.7 → lockfile resolves React to exactly 19.2.7
- Min Node ≥ 22.22.0 → Docker build stage uses `node:24-slim`
- ESM-only → project is `"type": "module"`, built with Vite

## Validation

- `npm run build` (`tsc -b && vite build`): ✓ 0 errors, 388 modules
- `npm run preview` smoke test: ✓ HTTP 200, SPA shell serves
- `npm install` audit: ✓ 0 vulnerabilities

Closes #84

## Security Checklist

- [x] No hardcoded secrets or credentials
- [x] Input validation on all user inputs (N/A — dependency bump only)
- [x] Auth/RBAC checks on protected endpoints (N/A)
- [x] Error messages don't leak internals (N/A)
- [x] GitHub Actions pinned to full commit SHAs (N/A — no workflow changes)